### PR TITLE
ENH: Enable folding of {...} and [...] blocks.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -12,6 +12,7 @@ Specific customizations
 * Added syntax highlighting warning for decimals smaller than 1 that don't start with a 0 (so .1 gives a warning, it should be 0.1).
 * Added syntax highlighting warning for comments and semicolons.
 * Added concealing of double quotes, for a minimalist CoffeScript-inspired look (requires Vim 7.3+ and setting conceallevel to 2).
+* Added folding of `{...}` and `[...]` blocks. The folding can be enabled via `:setlocal foldmethod=syntax` in a corresponding `ftplugin/json.vim` file.
 
 Screenshots
 -----------

--- a/syntax/json.vim
+++ b/syntax/json.vim
@@ -54,7 +54,8 @@ syn keyword jsonBoolean   true false
 syn keyword jsonNull      null
 
 " Syntax: Braces {{{2
-syn match   jsonBraces	   "[{}\[\]]"
+syn region jsonFold matchgroup=jsonBraces start="{" end="}" transparent fold
+syn region jsonFold matchgroup=jsonBraces start="\[" end="]" transparent fold
 
 " Define the default highlighting. {{{1
 " For version 5.7 and earlier: only when not done already


### PR DESCRIPTION
The folding can be enabled via :setlocal foldmethod=syntax in a corresponding ftplugin/json.vim file. It is off by default, so this is an opt-in change.
