### PR TITLE
Allow whitespace before name-separator in jsonKeywordMatch/Region.

### DIFF
--- a/syntax/json.vim
+++ b/syntax/json.vim
@@ -27,11 +27,11 @@ syn region  jsonStringSQ oneline  start=+'+  skip=+\\\\\|\\"+  end=+'+
 
 " Syntax: JSON Keywords
 " Separated into a match and region because a region by itself is always greedy
-syn match jsonKeywordMatch /"[^\"\:]\+"\:/ contains=jsonKeywordRegion
+syn match jsonKeywordMatch /"[^\"\:]\+"\s*\:/ contains=jsonKeywordRegion
 if has('conceal')
-   syn region jsonKeywordRegion matchgroup=Quote start=/"/  end=/"\ze\:/ concealends contained
+   syn region jsonKeywordRegion matchgroup=Quote start=/"/  end=/"\ze\s*\:/ concealends contained
 else
-   syn region jsonKeywordRegion matchgroup=Quote start=/"/  end=/"\ze\:/ contained
+   syn region jsonKeywordRegion matchgroup=Quote start=/"/  end=/"\ze\s*\:/ contained
 endif
 
 " Syntax: Escape sequences


### PR DESCRIPTION
The current keyword syntax highlighting regex successfully handles the
following json :

  "keyword":"value",
  "keyword": "value",

but does not match:

  "keyword" : "value",
  "keyword" :"value",

This patch permits keyword highlighting to work as intended in these
unsupported cases.

@see http://www.ietf.org/rfc/rfc4627.txt
