### PR TITLE
Turn off conceal completely if requested

### DIFF
--- a/ftplugin/json.vim
+++ b/ftplugin/json.vim
@@ -4,6 +4,10 @@ if !exists("g:vim_json_syntax_conceal")
 	let g:vim_json_syntax_conceal = 1
 end
 
-if has('conceal') && (g:vim_json_syntax_conceal == 1)
-	setlocal conceallevel=2
+if has('conceal')
+	if (g:vim_json_syntax_conceal == 1)
+		setlocal conceallevel=2
+	else
+		setlocal conceallevel=0
+	endif
 endif


### PR DESCRIPTION
It can be confusing if `g:vim_json_syntax_conceal` is set to `0` but `conceal`
is set to a non-zero value (e.g. `1` in my case) by the user's `.vimrc`.

This sets `conceal` to `0` if `g:vim_json_syntax_conceal` is set to `0`.
