### PR TITLE
A Couple Fixes, Tweaks and a Feature

### DIFF
--- a/syntax/json.vim
+++ b/syntax/json.vim
@@ -13,6 +13,8 @@ if !exists("main_syntax")
   let main_syntax = 'json'
 endif
 
+syntax match   jsonNoise           /\%(:\|,\)/
+
 " NOTE that for the concealing to work your conceallevel should be set to 2
 
 " Syntax: Strings
@@ -106,6 +108,7 @@ if version >= 508 || !exists("did_json_syn_inits")
   HiLink jsonStringSQ        Error
   HiLink jsonNoQuotes        Error
   HiLink jsonQuote           Quote
+  HiLink jsonNoise           Noise
   delcommand HiLink
 endif
 


### PR DESCRIPTION
A couple things in this pull request:
1. I fixed some whitespace inconsistencies throughout the file (for example, the use of tabs for alignment in the HiLink definitions when no other tabs exist in the file) and cleaned up some trailing whitespace.
2. Renamed the `Quote` matchgroup to `jsonQuote`, then `HiLink`'d that back to `Quote`. This provides colorscheme maintainers a finer level of granularity with their themes if they so prefer.
3. Added `jsonNoise` group that targets `:` and `,`, and mapped it back `Noise`
