### PR TITLE
Remove colon from jsonKeywordMatch

### DIFF
--- a/syntax/json.vim
+++ b/syntax/json.vim
@@ -31,7 +31,7 @@ syn region  jsonStringSQError oneline  start=+'+  skip=+\\\\\|\\"+  end=+'+
 
 " Syntax: JSON Keywords
 " Separated into a match and region because a region by itself is always greedy
-syn match  jsonKeywordMatch /"[^\"\:]\+"[[:blank:]\r\n]*\:/ contains=jsonKeyword
+syn match  jsonKeywordMatch /"[^\"]\+"[[:blank:]\r\n]*\:/ contains=jsonKeyword
 if has('conceal')
    syn region  jsonKeyword matchgroup=jsonQuote start=/"/  end=/"\ze[[:blank:]\r\n]*\:/ concealends contained
 else


### PR DESCRIPTION
so keys with colons are allowed.

I'd like to have proper highlighting in this document:

``` json
{
    "key:with:colons": 1
}
```

I don't quite understand, why it is there. So there's also #28 to allow colons in keys optionally.
