### PR TITLE
fix jsonStringMatch to include escapes

### DIFF
--- a/syntax/json.vim
+++ b/syntax/json.vim
@@ -19,7 +19,7 @@ syntax match   jsonNoise           /\%(:\|,\)/
 
 " Syntax: Strings
 " Separated into a match and region because a region by itself is always greedy
-syn match  jsonStringMatch /"[^\"]\+"\ze[[:blank:]\r\n]*[,}\]]/ contains=jsonString
+syn match  jsonStringMatch /"\([^"]\|\"\)\+"\ze[[:blank:]\r\n]*[,}\]]/ contains=jsonString
 if has('conceal')
 	syn region  jsonString oneline matchgroup=jsonQuote start=/"/  skip=/\\\\\|\\"/  end=/"/ concealends contains=jsonEscape contained
 else


### PR DESCRIPTION
Fixes a problem where escape sequences like \n cause the string to not be matched as a jsonString.
