### PR TITLE
Do concealing in syntax file only if enabled.

### DIFF
--- a/syntax/json.vim
+++ b/syntax/json.vim
@@ -19,7 +19,7 @@ syntax match   jsonNoise           /\%(:\|,\)/
 " Syntax: Strings
 " Separated into a match and region because a region by itself is always greedy
 syn match  jsonStringMatch /"\([^"]\|\\\"\)\+"\ze[[:blank:]\r\n]*[,}\]]/ contains=jsonString
-if has('conceal')
+if has('conceal') && g:vim_json_syntax_conceal == 1
 	syn region  jsonString oneline matchgroup=jsonQuote start=/"/  skip=/\\\\\|\\"/  end=/"/ concealends contains=jsonEscape contained
 else
 	syn region  jsonString oneline matchgroup=jsonQuote start=/"/  skip=/\\\\\|\\"/  end=/"/ contains=jsonEscape contained
@@ -31,7 +31,7 @@ syn region  jsonStringSQError oneline  start=+'+  skip=+\\\\\|\\"+  end=+'+
 " Syntax: JSON Keywords
 " Separated into a match and region because a region by itself is always greedy
 syn match  jsonKeywordMatch /"\([^"]\|\\\"\)\+"[[:blank:]\r\n]*\:/ contains=jsonKeyword
-if has('conceal')
+if has('conceal') && g:vim_json_syntax_conceal == 1
    syn region  jsonKeyword matchgroup=jsonQuote start=/"/  end=/"\ze[[:blank:]\r\n]*\:/ concealends contained
 else
    syn region  jsonKeyword matchgroup=jsonQuote start=/"/  end=/"\ze[[:blank:]\r\n]*\:/ contained


### PR DESCRIPTION
I installed [indentLine](https://github.com/Yggdroot/indentLine) plugin, and got issues like mentioned in issue https://github.com/elzr/vim-json/issues/23. 

Since setting 

`let g:vim_json_syntax_conceal = 0` and 
`let g:indentLine_noConcealCursor=""` or `let g:indentLine_noConcealCursor="nc"`

didn't work out properly, i noticed that when conceal is disabled manually (set to 0), syntax file still does concealing. Only the conceal cursor and level are not handled in that case. IndentLine sets conceallevel to 2, which automatically enables it for json, and i believe when someone disables the concealing manually expects not to have any of those functionality enabled, even when concealcursor/conceallevel is changed.

This is fixing the problem. I'm just not sure if it's good practice to use variables in syntax files.
