### PR TITLE
indent: Only use func shiftwidth() if it exists

### DIFF
--- a/indent/json.vim
+++ b/indent/json.vim
@@ -141,7 +141,11 @@ function GetJSONIndent()
 
   " If the previous line ended with a block opening, add a level of indent.
   " if s:Match(lnum, s:block_regex)
-    " return indent(lnum) + shiftwidth()
+  "   if exists('*shiftwidth')
+  "     return indent(lnum) + shiftwidth()
+  "   else
+  "     return indent(lnum) + &sw
+  "   endif
   " endif
 
   " If the previous line contained an opening bracket, and we are still in it,
@@ -149,7 +153,11 @@ function GetJSONIndent()
   if line =~ '[[({]'
     let counts = s:LineHasOpeningBrackets(lnum)
     if counts[0] == '1' || counts[1] == '1' || counts[2] == '1'
-      return ind + shiftwidth()
+      if exists('*shiftwidth')
+        return ind + shiftwidth()
+      else
+        return ind + &sw
+      endif
     else
       call cursor(v:lnum, vcol)
     end


### PR DESCRIPTION
shiftwidth() is not a builtin function, and my vim mojo isn't strong
enough to know where it could have come from. This change fallbacks to
using &sw instead of the shiftwidth() function, if the latter doesn't
exist.

Fixes Issue #48 in https://github.com/elzr/vim-json