### PR TITLE
Add optional support for comments

### DIFF
--- a/ftplugin/json.vim
+++ b/ftplugin/json.vim
@@ -16,6 +16,11 @@ if !exists("g:vim_json_warnings")
 	let g:vim_json_warnings = 1
 end
 
+"have comments off by default
+if !exists("g:vim_json_comments")
+	let g:vim_json_comments = 0
+end
+
 "set concealcursor blank by default
 "this should turn off the concealing in the current line (where the cursor is at),
 "on all modes (normal, visual, insert)

--- a/readme.md
+++ b/readme.md
@@ -23,6 +23,7 @@ Specific customizations
 	* Warn about *[missing commas](https://github.com/elzr/vim-json/issues/18)* between elements of an object [and elsewhere](https://github.com/elzr/vim-json/issues/34).
 	* Warn about *trailing commas* after the last element in arrays or objects.
 	* (All warnings can be turned off with a `let g:vim_json_warnings=0` in your `vimrc`.) 
+* Optionally allow comment syntax highlighting. (turn this on with a `let g:vim_json_comments=1` in your `vimrc`.)
 * Recognize `.jsonp` file type. In [JSONP](http://stackoverflow.com/questions/2067472/what-is-jsonp-all-about), the wrapping function call at the beginning and the closing semicolon are recognized.
 
 Screenshots

--- a/syntax/json.vim
+++ b/syntax/json.vim
@@ -60,9 +60,11 @@ if (!exists("g:vim_json_warnings") || g:vim_json_warnings==1)
 	" Syntax: Decimals smaller than one should begin with 0 (so .1 should be 0.1).
 	syn match   jsonNumError  "\:\@<=[[:blank:]\r\n]*\zs\.\d\+"
 
-	" Syntax: No comments in JSON, see http://stackoverflow.com/questions/244777/can-i-comment-a-json-file
-	syn match   jsonCommentError  "//.*"
-	syn match   jsonCommentError  "\(/\*\)\|\(\*/\)"
+  if (!exists("g:vim_json_comments") || g:vim_json_comments==0)
+    " Syntax: No comments in JSON, see http://stackoverflow.com/questions/244777/can-i-comment-a-json-file
+    syn match   jsonCommentError  "//.*"
+    syn match   jsonCommentError  "\(/\*\)\|\(\*/\)"
+  endif
 
 	" Syntax: No semicolons in JSON
 	syn match   jsonSemicolonError  ";"
@@ -75,6 +77,14 @@ if (!exists("g:vim_json_warnings") || g:vim_json_warnings==1)
 	syn match   jsonMissingCommaError /\(\]\|\}\)\_s\+\ze"/ "arrays/objects as values
 	syn match   jsonMissingCommaError /}\_s\+\ze{/ "objects as elements in an array
 	syn match   jsonMissingCommaError /\(true\|false\)\_s\+\ze"/ "true/false as value
+endif
+
+" COMMENTS ****************************************************
+if (exists("g:vim_json_comments") && g:vim_json_comments==1)
+  syn keyword jsonCommentTodo  TODO FIXME XXX TBD contained
+  syn match   jsonLineComment  "\/\/.*" contains=@Spell,jsonCommentTodo
+  syn match   jsonCommentSkip  "^[ \t]*\*\($\|[ \t]\+\)"
+  syn region  jsonComment      start="/\*"  end="\*/" contains=@Spell,jsonCommentTodo
 endif
 
 " ********************************************** END OF ERROR WARNINGS
@@ -117,6 +127,13 @@ if version >= 508 || !exists("did_json_syn_inits")
 		hi def link jsonNoQuotesError				Error
 		hi def link jsonTripleQuotesError		Error
   endif
+
+  if (exists("g:vim_json_comments") && g:vim_json_comments==1)
+    hi def link jsonCommentTodo Todo
+    hi def link jsonLineComment Comment
+    hi def link jsonComment     Comment
+  endif
+
   hi def link jsonQuote			Quote
   hi def link jsonNoise			Noise
 endif


### PR DESCRIPTION
While not officially part of the JSON standard, there are many parsers which will accept comments.

This change allows users to set an option which recognizes comments as comments instead of an error.
