### PR TITLE
Use Boolean and Number highlights for jsonBoolean and jsonNumber

### DIFF
--- a/syntax/json.vim
+++ b/syntax/json.vim
@@ -101,10 +101,10 @@ if version >= 508 || !exists("did_json_syn_inits")
   hi def link jsonString		String
   hi def link jsonTest			Label
   hi def link jsonEscape		Special
-  hi def link jsonNumber		Delimiter
+  hi def link jsonNumber		Number
   hi def link jsonBraces		Delimiter
   hi def link jsonNull			Function
-  hi def link jsonBoolean		Delimiter
+  hi def link jsonBoolean		Boolean
   hi def link jsonKeyword		Label
 
 	if (!exists("g:vim_json_warnings") || g:vim_json_warnings==1)


### PR DESCRIPTION
Currently they're highlighted as `Delimiter`. But there are
`Boolean` and `Number` for boolean values and numbers by default.
If there is no special reason, vim-json should use them.

Official syntax/json.vim does it.

https://github.com/vim/vim/blob/master/runtime/syntax/json.vim