### PR TITLE
Disable python use in Neovim

### DIFF
--- a/ftplugin/json.vim
+++ b/ftplugin/json.vim
@@ -36,3 +36,8 @@ if has('conceal')
 	"maybe g:vim_json_syntax_conceal could be settable to 0,1,2 to map
 	"directly to vim's conceallevels? unsure if anyone cares
 endif
+
+" for neovim
+if has('nvim')
+	let s:use_python = 0
+endif


### PR DESCRIPTION
This commit disables python when running under Neovim.
Becouse vim-json can not work fine without this when has python in neovim.