### PR TITLE
add jsonl support

### DIFF
--- a/ftdetect/json.vim
+++ b/ftdetect/json.vim
@@ -1,4 +1,5 @@
 autocmd BufNewFile,BufRead *.json setlocal filetype=json
+autocmd BufNewFile,BufRead *.jsonl setlocal filetype=json
 autocmd BufNewFile,BufRead *.jsonp setlocal filetype=json
 autocmd BufNewFile,BufRead *.geojson setlocal filetype=json
 autocmd BufNewFile,BufRead *.template setlocal filetype=json

--- a/jsonl-test.jsonl
+++ b/jsonl-test.jsonl
@@ -1,0 +1,4 @@
+{"name": "Gilbert", "wins": [["straight", "7♣"], ["one pair", "10♥"]]}
+{"name": "Alexa", "wins": [["two pair", "4♠"], ["two pair", "9♠"]]}
+{"name": "May", "wins": []}
+{"name": "Deloise", "wins": [["three of a kind", "5♣"]]}

--- a/syntax/json.vim
+++ b/syntax/json.vim
@@ -71,10 +71,12 @@ if (!exists("g:vim_json_warnings") || g:vim_json_warnings==1)
 	syn match   jsonTrailingCommaError  ",\_s*[}\]]"
 
 	" Syntax: Watch out for missing commas between elements
-	syn match   jsonMissingCommaError /\("\|\]\|\d\)\zs\_s\+\ze"/
-	syn match   jsonMissingCommaError /\(\]\|\}\)\_s\+\ze"/ "arrays/objects as values
-	syn match   jsonMissingCommaError /}\_s\+\ze{/ "objects as elements in an array
-	syn match   jsonMissingCommaError /\(true\|false\)\_s\+\ze"/ "true/false as value
+  syn match   jsonMissingCommaError /\("\|\]\|\d\)\zs\_s\+\ze"/
+  syn match   jsonMissingCommaError /\(\]\|\}\)\_s\+\ze"/ "arrays/objects as values
+  if (expand('%:e') !=? 'jsonl')
+    syn match   jsonMissingCommaError /}\_s\+\ze{/ "objects as elements in an array
+  endif
+  syn match   jsonMissingCommaError /\(true\|false\)\_s\+\ze"/ "true/false as value
 endif
 
 " ********************************************** END OF ERROR WARNINGS


### PR DESCRIPTION
This patch:

- [x] adds `jsonl` filetype's detection
- [x] disable trailing commas syntax error for object if filetype is equal to `jsonl`.

Closes #86 