### PR TITLE
Properly highlight stringified JSON

### DIFF
--- a/json-test.json
+++ b/json-test.json
@@ -54,6 +54,16 @@
     }
 }
 
+// nested and escaped strings
+{
+  "stringified json": "{\"bar\": \"qux\"}",
+  "like stringified json, but not": "{\"bar\"}",
+  "also like stringified json, but not": "{\"bar\" \"qux\"}",
+  "malformatted nested stringified json": "{\"bar\": "qux"}",
+  "number": 123,
+  "boolean": true,
+  "null": null
+}
 
 {"widget": {
     "debug": "on",

--- a/syntax/json.vim
+++ b/syntax/json.vim
@@ -22,7 +22,7 @@ syntax match   jsonNoise           /\%(:\|,\)/
 
 " Syntax: Strings
 " Separated into a match and region because a region by itself is always greedy
-syn match  jsonStringMatch /"\([^"]\|\\\"\)\+"\ze[[:blank:]\r\n]*[,}\]]/ contains=jsonString
+syn match  jsonStringMatch /"\([^"]\|\\"\)\+\\\@<!"\ze[[:blank:]\r\n]*[,}\]]/ contains=jsonString
 if has('conceal') && g:vim_json_syntax_conceal == 1
 	syn region  jsonString oneline matchgroup=jsonQuote start=/"/  skip=/\\\\\|\\"/  end=/"/ concealends contains=jsonEscape contained
 else
@@ -34,7 +34,7 @@ syn region  jsonStringSQError oneline  start=+'+  skip=+\\\\\|\\"+  end=+'+
 
 " Syntax: JSON Keywords
 " Separated into a match and region because a region by itself is always greedy
-syn match  jsonKeywordMatch /"\([^"]\|\\\"\)\+"[[:blank:]\r\n]*\:/ contains=jsonKeyword
+syn match  jsonKeywordMatch /"\([^"]\|\\"\)\+\\\@<!"[[:blank:]\r\n]*\:/ contains=jsonKeyword
 if has('conceal') && g:vim_json_syntax_conceal == 1
    syn region  jsonKeyword matchgroup=jsonQuote start=/"/  end=/"\ze[[:blank:]\r\n]*\:/ concealends contains=jsonEscape contained
 else


### PR DESCRIPTION
The problem was code like this:

```json
{
 "foo": "{\"bar\": \"qux\"}",
 "_":  "└────────┘ <- jsonKeywordMatch (!)"
}
```

before, we'd highlight the value of the "foo" key as if it were JSON,
because `jsonKeywordMatch` would match against the region shown above.

By adding the `\\\@<!` before the `"` we ensure that a \ doesn't come
before the `"`; a keyword must be terminated by an unescaped quote.