### PR TITLE
Don't assume that *.template files are JSON

### DIFF
--- a/ftdetect/json.vim
+++ b/ftdetect/json.vim
@@ -2,4 +2,3 @@ autocmd BufNewFile,BufRead *.json setlocal filetype=json
 autocmd BufNewFile,BufRead *.jsonl setlocal filetype=json
 autocmd BufNewFile,BufRead *.jsonp setlocal filetype=json
 autocmd BufNewFile,BufRead *.geojson setlocal filetype=json
-autocmd BufNewFile,BufRead *.template setlocal filetype=json


### PR DESCRIPTION
Files whose name ends in *.template may be in one of many formats. This plugin shouldn't unconditionally assume that they are all JSON files.