### PR TITLE
add option to colorize quotes

### DIFF
--- a/ftplugin/json.vim
+++ b/ftplugin/json.vim
@@ -11,6 +11,11 @@ if !exists("g:vim_json_syntax_conceal")
 	let g:vim_json_syntax_conceal = 1
 end
 
+"don't colorize quotes by default
+if !exists("g:vim_json_color_quotes")
+	let g:vim_json_color_quotes = 0
+end
+
 "have warnings by default
 if !exists("g:vim_json_warnings")
 	let g:vim_json_warnings = 1

--- a/readme.md
+++ b/readme.md
@@ -24,6 +24,7 @@ Specific customizations
 	* Warn about *trailing commas* after the last element in arrays or objects.
 	* (All warnings can be turned off with a `let g:vim_json_warnings=0` in your `vimrc`.) 
 * Recognize `.jsonp` file type. In [JSONP](http://stackoverflow.com/questions/2067472/what-is-jsonp-all-about), the wrapping function call at the beginning and the closing semicolon are recognized.
+* Added option for **colored quotes**. To enable it add `let g:vim_json_color_quotes=1` to your `.vimrc`.
 
 Screenshots
 -----------

--- a/syntax/json.vim
+++ b/syntax/json.vim
@@ -16,6 +16,22 @@ if !exists("main_syntax")
   let main_syntax = 'json'
 endif
 
+" parse options and set vars
+if has('conceal') && g:vim_json_syntax_conceal == 1
+   let conceal = " concealends"
+else
+   let conceal = ""
+endif
+
+if g:vim_json_color_quotes == 1
+	let keyword_quote_match_group = "jsonKeywordQuote"
+	let string_quote_match_group  = "jsonStringQuote"
+else
+	let keyword_quote_match_group = "jsonQuote"
+	let string_quote_match_group  = "jsonQuote"
+endif
+
+
 syntax match   jsonNoise           /\%(:\|,\)/
 
 " NOTE that for the concealing to work your conceallevel should be set to 2
@@ -23,11 +39,7 @@ syntax match   jsonNoise           /\%(:\|,\)/
 " Syntax: Strings
 " Separated into a match and region because a region by itself is always greedy
 syn match  jsonStringMatch /"\([^"]\|\\\"\)\+"\ze[[:blank:]\r\n]*[,}\]]/ contains=jsonString
-if has('conceal') && g:vim_json_syntax_conceal == 1
-	syn region  jsonString oneline matchgroup=jsonQuote start=/"/  skip=/\\\\\|\\"/  end=/"/ concealends contains=jsonEscape contained
-else
-	syn region  jsonString oneline matchgroup=jsonQuote start=/"/  skip=/\\\\\|\\"/  end=/"/ contains=jsonEscape contained
-endif
+execute 'syn region  jsonString oneline matchgroup=' . string_quote_match_group . ' start=/"/  skip=/\\\\\|\\"/  end=/"/ contains=jsonEscape contained' . conceal
 
 " Syntax: JSON does not allow strings with single quotes, unlike JavaScript.
 syn region  jsonStringSQError oneline  start=+'+  skip=+\\\\\|\\"+  end=+'+
@@ -35,11 +47,7 @@ syn region  jsonStringSQError oneline  start=+'+  skip=+\\\\\|\\"+  end=+'+
 " Syntax: JSON Keywords
 " Separated into a match and region because a region by itself is always greedy
 syn match  jsonKeywordMatch /"\([^"]\|\\\"\)\+"[[:blank:]\r\n]*\:/ contains=jsonKeyword
-if has('conceal') && g:vim_json_syntax_conceal == 1
-   syn region  jsonKeyword matchgroup=jsonQuote start=/"/  end=/"\ze[[:blank:]\r\n]*\:/ concealends contains=jsonEscape contained
-else
-   syn region  jsonKeyword matchgroup=jsonQuote start=/"/  end=/"\ze[[:blank:]\r\n]*\:/ contains=jsonEscape contained
-endif
+execute 'syn region  jsonKeyword matchgroup=' . keyword_quote_match_group . ' start=/"/  end=/"\ze[[:blank:]\r\n]*\:/ contains=jsonEscape contained' . conceal
 
 " Syntax: Escape sequences
 syn match   jsonEscape    "\\["\\/bfnrt]" contained
@@ -121,6 +129,8 @@ if version >= 508 || !exists("did_json_syn_inits")
   endif
   hi def link jsonQuote			Quote
   hi def link jsonNoise			Noise
+  hi def link jsonKeywordQuote	jsonKeyword
+  hi def link jsonStringQuote	jsonString
 endif
 
 let b:current_syntax = "json"


### PR DESCRIPTION
I'm not a huge fan of the quote concealing but I do appreciate how jq colors quotes to match their values to make the output less noisy.
This PR adds an option to colorize quotes. It defaults to off for compatibility, and works alongside syntax concealing.
Add `set g:vim_json_color_quotes=1` to enable