### PR TITLE
add support for concatonated/newline-delimited json

### DIFF
--- a/ftdetect/json.vim
+++ b/ftdetect/json.vim
@@ -1,5 +1,7 @@
 autocmd BufNewFile,BufRead *.json setlocal filetype=json
 autocmd BufNewFile,BufRead *.jsonl setlocal filetype=json
 autocmd BufNewFile,BufRead *.jsonp setlocal filetype=json
+autocmd BufNewFile,BufRead *.cjson setlocal filetype=json
+autocmd BufNewFile,BufRead *.ndjson setlocal filetype=json
 autocmd BufNewFile,BufRead *.geojson setlocal filetype=json
 autocmd BufNewFile,BufRead *.template setlocal filetype=json

--- a/syntax/json.vim
+++ b/syntax/json.vim
@@ -73,7 +73,7 @@ if (!exists("g:vim_json_warnings") || g:vim_json_warnings==1)
 	" Syntax: Watch out for missing commas between elements
   syn match   jsonMissingCommaError /\("\|\]\|\d\)\zs\_s\+\ze"/
   syn match   jsonMissingCommaError /\(\]\|\}\)\_s\+\ze"/ "arrays/objects as values
-  if (expand('%:e') !=? 'jsonl')
+  if (expand('%:e') !~? '\(cjson\|ndjson\|jsonl\)')
     syn match   jsonMissingCommaError /}\_s\+\ze{/ "objects as elements in an array
   endif
   syn match   jsonMissingCommaError /\(true\|false\)\_s\+\ze"/ "true/false as value


### PR DESCRIPTION
Not an in-depth level of support, but avoids error indications at end of objects by treating .cjson and .ndjson files the same as jsonl.