### PR TITLE
fix: don't set conceallevel from syntax plugin

### DIFF
--- a/syntax/json.vim
+++ b/syntax/json.vim
@@ -3,10 +3,6 @@
 " Maintainer:	Eli Parra <eli@elzr.com> https://github.com/elzr/vim-json
 " Last Change:	2014-12-20 Load ftplugin/json.vim
 
-" Reload the definition of g:vim_json_syntax_conceal
-" see https://github.com/elzr/vim-json/issues/42
-runtime! ftplugin/json.vim
-
 if !exists("main_syntax")
   if version < 600
     syntax clear
@@ -23,7 +19,7 @@ syntax match   jsonNoise           /\%(:\|,\)/
 " Syntax: Strings
 " Separated into a match and region because a region by itself is always greedy
 syn match  jsonStringMatch /"\([^"]\|\\\"\)\+"\ze[[:blank:]\r\n]*[,}\]]/ contains=jsonString
-if has('conceal') && g:vim_json_syntax_conceal == 1
+if has('conceal') && (!exists('g:vim_json_syntax_conceal') || g:vim_json_syntax_conceal == 1)
 	syn region  jsonString oneline matchgroup=jsonQuote start=/"/  skip=/\\\\\|\\"/  end=/"/ concealends contains=jsonEscape contained
 else
 	syn region  jsonString oneline matchgroup=jsonQuote start=/"/  skip=/\\\\\|\\"/  end=/"/ contains=jsonEscape contained
@@ -35,7 +31,7 @@ syn region  jsonStringSQError oneline  start=+'+  skip=+\\\\\|\\"+  end=+'+
 " Syntax: JSON Keywords
 " Separated into a match and region because a region by itself is always greedy
 syn match  jsonKeywordMatch /"\([^"]\|\\\"\)\+"[[:blank:]\r\n]*\:/ contains=jsonKeyword
-if has('conceal') && g:vim_json_syntax_conceal == 1
+if has('conceal') && (!exists('g:vim_json_syntax_conceal') || g:vim_json_syntax_conceal == 1)
    syn region  jsonKeyword matchgroup=jsonQuote start=/"/  end=/"\ze[[:blank:]\r\n]*\:/ concealends contains=jsonEscape contained
 else
    syn region  jsonKeyword matchgroup=jsonQuote start=/"/  end=/"\ze[[:blank:]\r\n]*\:/ contains=jsonEscape contained


### PR DESCRIPTION
I noticed that when I load a markdown file in vim, the `vim-json` file automatically runs `set conceallevel=2`. There's a few configs which are necessary to reproduce this:

1. vimrc should have `let g:markdown_fenced_languages = [ 'json', ... ]`
2. Install `elzr/vim-json` plugin
3. Load any markdown file

When these conditions are met, the markdown plugin will load the `vim-json/syntax/json.vim` script. The problem is that this script does something unusual by also loading the corresponding `ftplugin` script. Since loading the `ftplugin` script is the root cause, the fix is to stop loading this script. Because the `g:vim_json_syntax_conceal` plugin might be uninitialized now, this guards the references with `exists()` expressions. This is the same pattern as used in the builtin json syntax plugin (`vim/runtime/syntax/json.vim`).

I tested this with:

* `set conceallevel=2 | let g:vim_json_syntax_conceal = 0`
* `set conceallevel=0 | let g:vim_json_syntax_conceal = 1`
* and also with default settings

Fixes #104